### PR TITLE
add ability to have graph populate from right to left

### DIFF
--- a/src/ofxHistoryPlot.cpp
+++ b/src/ofxHistoryPlot.cpp
@@ -45,6 +45,7 @@ ofxHistoryPlot::ofxHistoryPlot(float * val, string varName, float maxHistory, bo
 	smoothValue = 0;
 	showSmoothedPlot = false;
 	lineColor = ofColor(255,0,0);
+	drawFromRight = false;
 }
 
 void ofxHistoryPlot::setMaxHistory(int max){
@@ -149,8 +150,14 @@ void ofxHistoryPlot::refillPlotMesh(ofVboMesh& mesh, vector<float> & vals, float
 	float loww = lowest - 0.001f;
 	float highh = highest + 0.001f;
 
+	float offset = 0;
+	float curMaxX = MAX_HISTORY;
+	if (drawFromRight && vals.size() < MAX_HISTORY) {
+		offset = w - vals.size() * w / MAX_HISTORY;
+		curMaxX = vals.size();
+	}
 	for (int i =  start; i < vals.size(); i+= drawSkip){
-		float xx = ofMap(i, 0, MAX_HISTORY, 0, w, false);
+		float xx = ofMap(i, 0, curMaxX, offset, w, false);
 		float yy = ofMap( vals[i], loww, highh, border, h - border, true);
 		mesh.addVertex(ofVec3f(x + xx, y + h - yy));
 	}
@@ -259,6 +266,10 @@ void ofxHistoryPlot::setRange(float low, float high){
 	onlyLowestIsFixed = false;
 	lowest = low;
 	highest = high;
+}
+
+void ofxHistoryPlot::setDrawFromRight(bool _val) {
+	drawFromRight = _val;
 }
 
 float ofxHistoryPlot::getLowerRange(){

--- a/src/ofxHistoryPlot.h
+++ b/src/ofxHistoryPlot.h
@@ -49,6 +49,7 @@ class ofxHistoryPlot{
 		void setDrawGrid(bool d) { drawGrid = d;}
 		void setGridUnit(float g){gridUnit = g;} //pixels
 		void setAutoRangeShrinksBack(bool shrink){shrinkBackInAutoRange = shrink;};
+		void setDrawFromRight(bool val); //begin drawing graph from right instead of left
 		void reset();
 		float getLowerRange();
 		float getHigerRange();
@@ -81,6 +82,7 @@ class ofxHistoryPlot{
 		bool			respectBorders;
 		bool			drawGrid;
 		bool			shrinkBackInAutoRange;
+		bool			drawFromRight; //begin drawing graph from right instead of left
 
 		int				MAX_HISTORY;
 		int				index;


### PR DESCRIPTION
This adds functionality to make the graph initially populate from right to left.

Use case: I'm using this for interactive time-series piece displaying a thermocam video feed. When a user touches a region, a short graph of the current temperature occurs alongside other streaming graphs. The graph of the recently touched position needs to draw from the right for the streaming graphs to line up.
